### PR TITLE
Rollover Labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,24 +103,42 @@ class ImageCanvas(tk.Canvas):
         if self.rollingover_label == False:
             self.clear_labels()
 
-        if len(self.labels) > 0:
+        if os.path.exists(label_filename) and self.rollingover_label == True:
             print ("labels exist, no need to overwrite")
+            self.clear_labels()
+            if os.path.exists(label_filename):
+                print("Loading existing labels for", image_filename)
+                #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
+                #draw labels from file onto canvas
+                with open(label_filename, "r") as yolo_label_file:
+                    yolo_labels = yolo_label_file.read().splitlines()
+                    for yolo_label in yolo_labels:
+                        class_index, x, y, width, height = yolo_label.split(" ")
+                        class_index = int(class_index)
+                        x, y, width, height = float(x), float(y), float(width), float(height)
+                        class_name = CLASSES[class_index]
+                        bb = [x,y, x+width, y+height]
+                        bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
+                        new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
+                        self.labels.append([bb,class_name,bb_id, new_label_text_id])
         else:
             if os.path.exists(label_filename):
-                    print("Loading existing labels for", image_filename)
-                    #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
-                    #draw labels from file onto canvas
-                    with open(label_filename, "r") as yolo_label_file:
-                        yolo_labels = yolo_label_file.read().splitlines()
-                        for yolo_label in yolo_labels:
-                            class_index, x, y, width, height = yolo_label.split(" ")
-                            class_index = int(class_index)
-                            x, y, width, height = float(x), float(y), float(width), float(height)
-                            class_name = CLASSES[class_index]
-                            bb = [x,y, x+width, y+height]
-                            bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
-                            new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
-                            self.labels.append([bb,class_name,bb_id, new_label_text_id])
+                print("loading existing labels for", image_filename)
+                #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
+                #draw labels from file onto canvas
+                with open(label_filename, "r") as yolo_label_file:
+                    yolo_labels = yolo_label_file.read().splitlines()
+                    for yolo_label in yolo_labels:
+                        class_index, x, y, width, height = yolo_label.split(" ")
+                        class_index = int(class_index)
+                        x, y, width, height = float(x), float(y), float(width), float(height)
+                        class_name = CLASSES[class_index]
+                        bb = [x,y, x+width, y+height]
+                        bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
+                        new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
+                        self.labels.append([bb,class_name,bb_id, new_label_text_id])
+       
+
         print("labels:")
         for label in self.labels:
             print(label)

--- a/main.py
+++ b/main.py
@@ -112,8 +112,6 @@ class ImageCanvas(tk.Canvas):
         else:
             if os.path.exists(label_filename):
                     print("Loading existing labels for", image_filename)
-                    #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
-                    #draw labels from file onto canvas
                     with open(label_filename, "r") as yolo_label_file:
                         yolo_labels = yolo_label_file.read().splitlines()
                         for yolo_label in yolo_labels:
@@ -238,7 +236,8 @@ class App(tk.Tk):
     def __init__(self):
         tk.Tk.__init__(self)
         self.filename_label = None
-        self.mode_label = None
+        self.mode_label = None              # refers to rollover/edit mode
+        self.adding_box_label = None      # refers to add/delete box
         self.create_widget_frame()
 
         self.create_menu()
@@ -283,12 +282,17 @@ class App(tk.Tk):
         self.class_optionmenu.grid(widget_config, row=current_row)
         current_row += 1
 
-
-        tk.Label(widget_frame, text='Mode: ').grid(label_config, row=current_row)
+        tk.Label(widget_frame, text='Rolling labels: ').grid(label_config, row=current_row)
         self.mode_label = tk.Label(widget_frame, text='')
         self.mode_label.grid(label_config, row=current_row)
-        self.mode_label.config(text="Mode: " + "editing")
+        self.mode_label.config(text="Rolling labels: " + "False")
+        current_row += 1
 
+        tk.Label(widget_frame, text='Adding boxes: ').grid(label_config, row=current_row)
+        self.adding_box_label = tk.Label(widget_frame, text='')
+        self.adding_box_label.grid(label_config, row=current_row)
+        self.adding_box_label.config(text="Adding boxes: " + "True")
+        current_row += 1
 
         widget_frame.pack(fill=tk.X, expand=tk.NO)
 
@@ -328,12 +332,13 @@ class App(tk.Tk):
             cross_hair_color = "red" if self.frame_canvas.editing else CROSS_HAIR_COLORS[SELECTED_CROSS_HAIR_COLOR_INDEX]
             self.frame_canvas.itemconfig(self.frame_canvas.horizontal_dash_line, fill=cross_hair_color)
             self.frame_canvas.itemconfig(self.frame_canvas.vertical_dash_line, fill=cross_hair_color)
+            self.adding_box_label.config(text="Adding boxes: " + str(not self.frame_canvas.editing))
         elif event.char == "z":
             print("Deleting last box...");
             self.frame_canvas.clear_last_label()
         elif event.char == "r":
             self.frame_canvas.rollingover_label = not self.frame_canvas.rollingover_label
-            self.mode_label.config(text="Mode: " + "rollover") if self.frame_canvas.rollingover_label == True else self.mode_label.config(text="Mode: " + "editing")
+            self.mode_label.config(text="Rolling Labels: " + str(self.frame_canvas.rollingover_label))
             print("r pressed rollover is now", self.frame_canvas.rollingover_label)
 
 

--- a/main.py
+++ b/main.py
@@ -108,8 +108,8 @@ class ImageCanvas(tk.Canvas):
         else:
             if os.path.exists(label_filename):
                     print("Loading existing labels for", image_filename)
-                        #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
-                        #draw labels from file onto canvas
+                    #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
+                    #draw labels from file onto canvas
                     with open(label_filename, "r") as yolo_label_file:
                         yolo_labels = yolo_label_file.read().splitlines()
                         for yolo_label in yolo_labels:
@@ -121,7 +121,7 @@ class ImageCanvas(tk.Canvas):
                             bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
                             new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
                             self.labels.append([bb,class_name,bb_id, new_label_text_id])
-                            print("labels:")
+        print("labels:")
         for label in self.labels:
             print(label)
 
@@ -234,6 +234,7 @@ class App(tk.Tk):
     def __init__(self):
         tk.Tk.__init__(self)
         self.filename_label = None
+        self.mode_label = None
         self.create_widget_frame()
 
         self.create_menu()
@@ -265,6 +266,7 @@ class App(tk.Tk):
         current_row = 0
 
         tk.Label(widget_frame, text='Current File: ').grid(label_config, row=current_row)
+
         self.filename_label = tk.Label(widget_frame, text='')
         self.filename_label.grid(label_config, row=current_row)
         current_row += 1
@@ -276,6 +278,13 @@ class App(tk.Tk):
         self.selected_optionmenu.trace("w", self.updated_class_combobox)
         self.class_optionmenu.grid(widget_config, row=current_row)
         current_row += 1
+
+
+        tk.Label(widget_frame, text='Mode: ').grid(label_config, row=current_row)
+        self.mode_label = tk.Label(widget_frame, text='')
+        self.mode_label.grid(label_config, row=current_row)
+        self.mode_label.config(text="Mode: " + "editing")
+
 
         widget_frame.pack(fill=tk.X, expand=tk.NO)
 
@@ -320,6 +329,7 @@ class App(tk.Tk):
             self.frame_canvas.clear_last_label()
         elif event.char == "r":
             self.frame_canvas.rollingover_label = not self.frame_canvas.rollingover_label
+            self.mode_label.config(text="Mode: " + "rollover") if self.frame_canvas.rollingover_label == True else self.mode_label.config(text="Mode: " + "editing")
             print("r pressed rollover is now", self.frame_canvas.rollingover_label)
 
 

--- a/main.py
+++ b/main.py
@@ -104,41 +104,27 @@ class ImageCanvas(tk.Canvas):
             self.clear_labels()
 
         if os.path.exists(label_filename) and self.rollingover_label == True:
-            print ("labels exist, no need to overwrite")
+            print("labels exist, don't overwrite")
             self.clear_labels()
-            if os.path.exists(label_filename):
-                print("Loading existing labels for", image_filename)
-                #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
-                #draw labels from file onto canvas
-                with open(label_filename, "r") as yolo_label_file:
-                    yolo_labels = yolo_label_file.read().splitlines()
-                    for yolo_label in yolo_labels:
-                        class_index, x, y, width, height = yolo_label.split(" ")
-                        class_index = int(class_index)
-                        x, y, width, height = float(x), float(y), float(width), float(height)
-                        class_name = CLASSES[class_index]
-                        bb = [x,y, x+width, y+height]
-                        bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
-                        new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
-                        self.labels.append([bb,class_name,bb_id, new_label_text_id])
+
+        if len(self.labels) > 0:
+            print ("labels exist, no need to overwrite")
         else:
             if os.path.exists(label_filename):
-                print("loading existing labels for", image_filename)
-                #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
-                #draw labels from file onto canvas
-                with open(label_filename, "r") as yolo_label_file:
-                    yolo_labels = yolo_label_file.read().splitlines()
-                    for yolo_label in yolo_labels:
-                        class_index, x, y, width, height = yolo_label.split(" ")
-                        class_index = int(class_index)
-                        x, y, width, height = float(x), float(y), float(width), float(height)
-                        class_name = CLASSES[class_index]
-                        bb = [x,y, x+width, y+height]
-                        bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
-                        new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
-                        self.labels.append([bb,class_name,bb_id, new_label_text_id])
-       
-
+                    print("Loading existing labels for", image_filename)
+                    #MOVE HERE self.clear_labels() if you want to keep the previous frames labels
+                    #draw labels from file onto canvas
+                    with open(label_filename, "r") as yolo_label_file:
+                        yolo_labels = yolo_label_file.read().splitlines()
+                        for yolo_label in yolo_labels:
+                            class_index, x, y, width, height = yolo_label.split(" ")
+                            class_index = int(class_index)
+                            x, y, width, height = float(x), float(y), float(width), float(height)
+                            class_name = CLASSES[class_index]
+                            bb = [x,y, x+width, y+height]
+                            bb_id = self.create_rectangle(bb[0] * self.winfo_width(),bb[1] * self.winfo_height() ,bb[2] * self.winfo_width(),bb[3] * self.winfo_height(), fill="", outline=COLORS[class_index])
+                            new_label_text_id = self.create_text(x * self.winfo_width(), (y * self.winfo_height()) - 5, fill=COLORS[class_index], text=class_name)
+                            self.labels.append([bb,class_name,bb_id, new_label_text_id])
         print("labels:")
         for label in self.labels:
             print(label)

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class ImageCanvas(tk.Canvas):
         self.resized_photoimage = ImageTk.PhotoImage(self.resizeable_image)
         self.image_on_canvas = self.create_image(0,0, anchor=tk.NW, image=self.resized_photoimage, tag="all")
         self.config(cursor = 'none')
-        self.rollover_label = False
+        self.rollingover_label = False
 
         self.addtag_all("all")
         self.update()
@@ -94,14 +94,13 @@ class ImageCanvas(tk.Canvas):
             os.remove(label_filename)
 
 
-    def load_labels(self, image_filename, existing_labels, rollover_label):
+    def load_labels(self, image_filename):
         #check if label file exists
         label_filename = os.path.splitext(image_filename)[0] + ".txt"
         #self.clear_labels() #delete this line if you want to have labels roll over from previous frame
-        print(f"Rollover label: {self.rollover_label}")
-      
+        print("Rollingover label:", self.rollingover_label)      
        
-        if self.rollover_label == False:
+        if self.rollingover_label == False:
             self.clear_labels()
 
         if len(self.labels) > 0:
@@ -135,7 +134,7 @@ class ImageCanvas(tk.Canvas):
             else:
                 print("removing labels", self.image_filename)
                 self.delete_label_file()
-        self.load_labels(filename, self.labels, self.rollover_label)
+        self.load_labels(filename)
         self.image_filename = filename
         self.resizeable_image = Image.open(self.image_filename).resize((self.width, self.height), Image.ANTIALIAS)
         self.resized_photoimage = ImageTk.PhotoImage(self.resizeable_image)
@@ -320,10 +319,8 @@ class App(tk.Tk):
             print("Deleting last box...");
             self.frame_canvas.clear_last_label()
         elif event.char == "r":
-            self.frame_canvas.rollover_label = True
-            print(f"r pressed rollover is now {self.frame_canvas.rollover_label}")
-        elif event.char == "t":
-            self.frame_canvas.rollover_label = False
+            self.frame_canvas.rollingover_label = not self.frame_canvas.rollingover_label
+            print("r pressed rollover is now", self.frame_canvas.rollingover_label)
 
 
         elif event.char == "f":


### PR DESCRIPTION
Rollover mode can be enabled with "r" and disabled with "t". The boolean rollover_label is passed as an argument in the load_labels function. Labels from the next frame are cleared if it is false, preserved otherwise. An if condition checks if the next frame has any label on it or not, if it does they are preserved, if it doesn't they are copied from the previous frame.